### PR TITLE
Fix reference to native Logger in Marmot::Client

### DIFF
--- a/lib/marmot/client.rb
+++ b/lib/marmot/client.rb
@@ -12,7 +12,7 @@ module Marmot
     @@headers_set = false
 
     def initialize
-      logger = Logger.new("/dev/null")
+      logger = ::Logger.new("/dev/null")
       logger.close
     end
 


### PR DESCRIPTION
I got this error when using marmot:

```
/Library/Ruby/Gems/2.0.0/gems/marmot-0.0.5/lib/marmot/client.rb:15:in `initialize': undefined method `new' for HTTParty::Logger:Module (NoMethodError)
    from /Library/Ruby/Gems/2.0.0/gems/marmot-0.0.5/bin/marmot:116:in `new'
    from /Library/Ruby/Gems/2.0.0/gems/marmot-0.0.5/bin/marmot:116:in `start'
    from /Library/Ruby/Gems/2.0.0/gems/marmot-0.0.5/bin/marmot:125:in `<top (required)>'
    from /usr/bin/marmot:23:in `load'
    from /usr/bin/marmot:23:in `<main>'
```

It seems that's because HTTParty added a `Logger` class of its own.
