### PR TITLE
Fix boolean options from config files

### DIFF
--- a/bin/marmot
+++ b/bin/marmot
@@ -103,7 +103,7 @@ class Marmot::CLI
 
 
     if(config_file)
-      options_from_config = JSON.parse(config_file.read.gsub /^#.*$/, '')
+      options_from_config = JSON.parse(config_file.read.gsub(/^#.*$/, ''), {:symbolize_names => true})
       options_from_config = Marmot::OptionsSanitizer::FALSE_CHECKBOXES.merge(options_from_config)
       options = options_from_config.merge options
     end


### PR DESCRIPTION
Options from config files were parsed as string keys instead of symbols, which messed with the merging of the `FALSE_CHECKBOXES` hash, which uses symbols. So all boolean options were set to false regardless of their value in the config file.
