### PR TITLE
Windows support: logger should use STDOUT

### DIFF
--- a/lib/marmot/client.rb
+++ b/lib/marmot/client.rb
@@ -12,7 +12,7 @@ module Marmot
     @@headers_set = false
 
     def initialize
-      logger = ::Logger.new("/dev/null")
+      logger = ::Logger.new(STDOUT)
       logger.close
     end
 


### PR DESCRIPTION
/dev/null doesn't exist on windows. As a workaround I think logging to STDOUT by default is ok.