### PR TITLE
FontSquirrel now requires HTTPS

### DIFF
--- a/lib/marmot/client.rb
+++ b/lib/marmot/client.rb
@@ -6,7 +6,7 @@ module Marmot
   class Client
     include HTTMultiParty
 
-    base_uri 'www.fontsquirrel.com'
+    base_uri 'https://www.fontsquirrel.com'
     attr_accessor :logger
     attr_reader   :params
     @@headers_set = false


### PR DESCRIPTION
Otherwise you get a 301 redirect error.
